### PR TITLE
Optimize syntax for DB connection files

### DIFF
--- a/small-talk/app/accountCreate/page.js
+++ b/small-talk/app/accountCreate/page.js
@@ -2,7 +2,7 @@
 import Link from 'next/link'
 import React, { useState } from 'react';
 import userExists from "@/db/username"
-import handleRegister from "@/db/registerTest"
+import handleRegister from "@/db/registerToDB"
 
 export default function RegisterPage() {
     var status = "Submit"; // name/text for the button

--- a/small-talk/db/handleLogin.js
+++ b/small-talk/db/handleLogin.js
@@ -4,7 +4,6 @@ import Mongoboi from "./mongo"
 export default async function handleSubmit(username, password) {
   "use server"
   const mongoboi = new Mongoboi(uri, "Users")
-  const date = new Date('January 1, 1980');
   var filter = {
     username: username,
     password: password,
@@ -17,18 +16,4 @@ export default async function handleSubmit(username, password) {
     return user
   }
   return null;
-  //console.log(user)
-  /*
-  const response = await fetch('/api/auth/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password }),
-  })
-
-  if (response.ok) {
-    router.push('/profile')
-  } else {
-    // Handle errors
-  }
-  */
 }

--- a/small-talk/db/registerToDB.js
+++ b/small-talk/db/registerToDB.js
@@ -1,12 +1,12 @@
 "use server"
 const uri = "mongodb+srv://smt_root:pokemonwithguns@smalltalkcluster0.jo4jne6.mongodb.net/?retryWrites=true&w=majority"
 import Mongoboi from "./mongo"
-export default async function handleRegister(username, password, firstname, lastname, dob){
+export default async function handleRegister(username, password, firstname, lastname, dob){ // function that sends the credentials to the database
   const mongoboi = new Mongoboi(uri, "Users");
-  const date = new Date(dob).getTime() / 1000;
+  const date = new Date(dob).getTime() / 1000; // return the inputted date as a Unix timestamp
   await mongoboi.connect();
 
-  const newUser = {
+  const newUser = { // schema for holding the values into certain fields for database organization
     username: username,
     password: password,
     firstname: firstname,
@@ -15,7 +15,7 @@ export default async function handleRegister(username, password, firstname, last
   };
 
   try {
-    await mongoboi.connect();
+    await mongoboi.connect(); // establish connection to the database
     await mongoboi.insertOne("patients", newUser); // Inserting a new document into the "patients" collection
     return newUser; // Returning the newly inserted user
   } 
@@ -23,7 +23,7 @@ export default async function handleRegister(username, password, firstname, last
     console.error("Error writing to database:", error);
     return null; // Returning null if there's an error
   }
-  finally {
-    await mongoboi.disconnect();
+  finally { // ensure that the database connection is closed even if an exception is caught/thrown
+    await mongoboi.disconnect(); 
   }
 }

--- a/small-talk/db/registerToDB.js
+++ b/small-talk/db/registerToDB.js
@@ -3,6 +3,7 @@ const uri = "mongodb+srv://smt_root:pokemonwithguns@smalltalkcluster0.jo4jne6.mo
 import Mongoboi from "./mongo"
 export default async function handleRegister(username, password, firstname, lastname, dob){
   const mongoboi = new Mongoboi(uri, "Users");
+  const date = new Date(dob).getTime() / 1000;
   await mongoboi.connect();
 
   const newUser = {
@@ -10,19 +11,19 @@ export default async function handleRegister(username, password, firstname, last
     password: password,
     firstname: firstname,
     lastname: lastname,
-    dob: dob,
+    dob: date,
   };
 
   try {
     await mongoboi.connect();
     await mongoboi.insertOne("patients", newUser); // Inserting a new document into the "patients" collection
-    await mongoboi.disconnect();
     return newUser; // Returning the newly inserted user
   } 
-  
   catch (error) {
     console.error("Error writing to database:", error);
-    await mongoboi.disconnect();
     return null; // Returning null if there's an error
+  }
+  finally {
+    await mongoboi.disconnect();
   }
 }

--- a/small-talk/db/username.js
+++ b/small-talk/db/username.js
@@ -4,7 +4,6 @@ import Mongoboi from "./mongo"
 export default async function userExists(username) {
     "use server"
     const mongoboi = new Mongoboi(uri, "Users")
-    const date = new Date('January 1, 1980');
     var filter = {
       username: username, //check for existing username in db
     }

--- a/small-talk/package.json
+++ b/small-talk/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "NODE_ENV=test jest",
+    "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },

--- a/small-talk/package.json
+++ b/small-talk/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },


### PR DESCRIPTION
Fixes #74 

As MacGyver stated in #71, the dates of birth should be stored in Unix timestamps, and try-catch block can be optimized by using a 'finally' statement.

- Converted the dates of births from YYYY-MM-DD string format to Unix timestamp for DB space efficiency
- Try-Catch block now includes a 'finally' block to ensure that the DB connection will close if any exception is caught during DB processing