### PR TITLE
Additional test coverage for the other feature's pages.

### DIFF
--- a/small-talk/app/game/game.test.js
+++ b/small-talk/app/game/game.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Games from './page.js';
+
+/*
+    Test case for Games page in .../small-talk/app/game
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Games page renders properly 
+describe("Games Page", () =>
+{
+    it("Makes sure Games Page content renders properly", () =>
+    {   
+        // Render Games page
+        render(<Games />);
+
+        // Get page content
+        const titleElement = screen.getByText("Games Page");
+        const singlePlayer = screen.getByText("Singleplayer Games");
+        const multiplayer = screen.getByText("Multiplayer Games");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(singlePlayer).toBeInTheDocument();
+        expect(multiplayer).toBeInTheDocument();
+    })
+})

--- a/small-talk/app/health/health.test.js
+++ b/small-talk/app/health/health.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Health from './page.js';
+
+/*
+    Test case for Health page in .../small-talk/app/health
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Health page renders properly 
+describe("Health Page", () =>
+{
+    it("Makes sure Health Page content renders properly", () =>
+    {   
+        // Render Health page
+        render(<Health />);
+
+        // Get page content
+        const titleElement = screen.getByText("Health Page");
+        const doctor = screen.getByText("Doctor Information");
+        const nurse = screen.getByText("Nurse Information");
+        const chat = screen.getByText("Chatroom");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(doctor).toBeInTheDocument();
+        expect(nurse).toBeInTheDocument();
+        expect(chat).toBeInTheDocument();
+    })
+})

--- a/small-talk/app/homepage/homepage.test.js
+++ b/small-talk/app/homepage/homepage.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Homepage from './page.js';
+
+/*
+    Test case for Homepage page in .../small-talk/app/homepage
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Homepage renders properly 
+describe("Home Page", () =>
+{
+    it("Makes sure Home page content renders properly", () =>
+    {   
+        // Render Homepage
+        render(<Homepage />);
+
+        // Get page content
+        const titleElement = screen.getByText("Home Page");
+        const bb = screen.getByText("Bulletin Board");
+        const friends = screen.getByText("Friends");
+        const chat = screen.getByText("Chatroom");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(bb).toBeInTheDocument();
+        expect(friends).toBeInTheDocument();
+        expect(chat).toBeInTheDocument();
+    })
+})

--- a/small-talk/app/movie/movie.test.js
+++ b/small-talk/app/movie/movie.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Movie from './page.js';
+
+/*
+    Test case for Movie page in .../small-talk/app/movie
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Movie page renders properly 
+describe("Movie Page", () =>
+{
+    it("Makes sure Movie page content renders properly", () =>
+    {   
+        // Render Movie Page
+        render(<Movie />);
+
+        // Get page content
+        const titleElement = screen.getByText("Movies Page");
+        const media = screen.getByText("List of Media Applications");
+        const lFriends = screen.getByText("List of Friends currently watching");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(media).toBeInTheDocument();
+        expect(lFriends).toBeInTheDocument();
+    })
+})

--- a/small-talk/app/profile/page.js
+++ b/small-talk/app/profile/page.js
@@ -1,5 +1,6 @@
 "use client"
 import Link from 'next/link'
+import React from 'react';
 import ThemeLayout from '../components/ThemeLayout';
 
 export default function profile() {

--- a/small-talk/app/profile/profile.test.js
+++ b/small-talk/app/profile/profile.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Profile from './page.js';
+
+/*
+    Test case for Profile page in .../small-talk/app/profile
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Profile page renders properly 
+describe("Profile Page", () =>
+{
+    it("Makes sure Profile page content renders properly", () =>
+    {   
+        // Render Profile Page
+        render(<Profile />);
+
+        // Get page content
+        const titleElement = screen.getByText("Profile Page");
+        const avatar = screen.getByText("Avatar");
+        const pBoard = screen.getByText("Personalized Board");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(avatar).toBeInTheDocument();
+        expect(pBoard).toBeInTheDocument();
+    })
+})

--- a/small-talk/app/setting/page.js
+++ b/small-talk/app/setting/page.js
@@ -1,5 +1,6 @@
 "use client"
 import Link from 'next/link';
+import React from 'react';
 import ThemeLayout from '../components/ThemeLayout';
 
 export default function setting() {

--- a/small-talk/app/setting/settings.test.js
+++ b/small-talk/app/setting/settings.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Setting from './page.js';
+
+/*
+    Test case for Setting page in .../small-talk/app/setting
+    Check that the page renders and check if the expected content exists in the render
+*/
+
+// Test if Setting page renders properly 
+describe("Setting Page", () =>
+{
+    it("Makes sure Setting page content renders properly", () =>
+    {   
+        // Render Setting Page
+        render(<Setting />);
+
+        // Get page content
+        const titleElement = screen.getByText("Settings Page");
+        const ldt = screen.getByText("Light and Dark Theme");
+        const update = screen.getByText("Update Information");
+
+        // Check if expected content exists
+        expect(titleElement).toBeInTheDocument();
+        expect(ldt).toBeInTheDocument();
+        expect(update).toBeInTheDocument();
+    })
+})


### PR DESCRIPTION
### Creating basic test coverage for Game, Health, Homepage, Movie, Profile, and Setting. 
### Issue Number #58 
### Description
Similar to Matthew's PR, using that basic layout to add more test coverage on pages that weren't worked on this sprint but have future plans. Simply checking if the rendered page contains the expected content on the page. Had to also add a simple import line that was missing on two of the page.js. 
### Testing
All test cases made in this pull request pass since the page content is just static text and there is not any function to test. 
### Possible Errors
There was no errors but just like Matthew suggested in his PR, if there are better ways to test these pages then I am also open to suggestions. These pages and test will definitely be changed in the future but these are added now for test coverage and for place holders. 
### Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156875021/ca09ded1-2eb3-48da-b60a-955ad69d829c)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156875021/5a76a53d-ca8e-4dd3-b2c8-718392ec4103)
