### PR TITLE
Created test case for SidebarButton component

### DIFF
--- a/small-talk/app/components/SidebarButton.test.js
+++ b/small-talk/app/components/SidebarButton.test.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { screen, fireEvent, render } from '@testing-library/react';
+import SidebarButton from './SidebarButton';
+
+/*
+    Test case for the SidebarButton component in .../small-talk/app/components
+    Test 1: Renders SidebarButton then checks if correct image rendered when not hovered (defaultImg)
+    Test 2: Renders SidebarButton then checks if correct image rendered when hovered (hoverImg)
+    Test 3: Renders SidebarButton then checks if page redirects correctly when clicked **doesn't work currently**
+*/
+
+// jest.mock("next/link", () => { return ({children}) => { return children; }});
+
+// let originalLocation;
+
+// beforeAll(() =>
+// {
+//     originalLocation = window.location;
+//     delete window.location;
+//     window.location = { href: "", assign: jest.fn() };
+// });
+
+// afterAll(() =>
+// {
+//     window.location = originalLocation;
+// });
+
+describe("SidebarButton Component", () =>
+{
+    // Test 1: Renders SidebarButton then checks if correct image rendered when not hovered (defaultImg)
+    it("SidebarButton renders default image properly when not hovered", () =>
+    {
+        // SidebarButton properties -- using health button properties
+        const redirect = "/health";
+        const defaultImg = "/img/buttons/health-default.png";
+        const hoverImg = "/img/buttons/health-extend.png";
+        const altText = "Health";
+        
+        // Render SidebarButton using properties
+        render(<SidebarButton redirect = {redirect} 
+                              defaultImg = {defaultImg} 
+                              hoverImg = {hoverImg} 
+                              altText = {altText} />);
+
+        // Get SidebarButton from rendered component
+        const button = screen.getByAltText(altText);
+
+        // Check if component exists and has correct default image when not hovered
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute("src", defaultImg);
+    });
+    
+    // Test 2: Renders SidebarButton then checks if correct image rendered when hovered (hoverImg)
+    it("SidebarButton renders hover image properly when hovered", () =>
+    {
+        // SidebarButton properties -- using events button properties
+        const redirect = "/events";
+        const defaultImg = "/img/buttons/event-default.png";
+        const hoverImg = "/img/buttons/event-extend.png";
+        const altText = "Events";
+        
+        // Render SidebarButton using properties
+        render(<SidebarButton redirect = {redirect} 
+                              defaultImg = {defaultImg} 
+                              hoverImg = {hoverImg} 
+                              altText = {altText} />);
+
+        // Get SidebarButton from rendered component
+        const button = screen.getByAltText(altText);
+        
+        // Simulate mouse cursor hovering button
+        fireEvent.mouseEnter(button);
+
+        // Check if component changes to correct image when hovered
+        expect(button).toHaveAttribute("src", hoverImg);
+        
+        // Simulate mouse cursor unhovering button
+        fireEvent.mouseLeave(button);
+        
+        // Check if component changes back to correct image when not hovered
+        expect(button).toHaveAttribute("src", defaultImg);
+    });
+    
+    // Test 3: Renders SidebarButton then checks if page redirects correctly when clicked **doesn't work currently**
+    // it("SidebarButton redirects to correct page properly when clicked", () =>
+    // {
+    //     // SidebarButton properties -- using chat button properties
+    //     const redirect = "/chat";
+    //     const defaultImg = "/img/buttons/chat-default.png";
+    //     const hoverImg = "/img/buttons/chat-extend.png";
+    //     const altText = "Chat";
+    
+    //     // Render SidebarButton using properties
+    //     render(<SidebarButton redirect = {redirect} 
+    //                           defaultImg = {defaultImg} 
+    //                           hoverImg = {hoverImg} 
+    //                           altText = {altText} />);
+    
+    //     // Get SidebarButton from rendered component
+    //     const button = screen.getByAltText(altText);
+    
+    //     // Simulate mouse click on button
+    //     fireEvent.click(button);
+    
+    //     // Check if component redirects to page properly
+    //     expect(window.location.href).toBe(redirect);
+    // });
+});


### PR DESCRIPTION
## Created test case for SidebarButton component
## Issue Number
#58 Expand test coverage to 90%
## Description
Includes 3 tests for the SidebarButton component, currently only 2/3 tests work. 
- Test 1 checks to see if the SidebarButton renders the correct image when not hovered.
- Test 2 checks to see if the SidebarButton renders the correct image when hovered.
- Test 3 checks to see if the SidebarButton redirects to the correct page when clicked.

Test 1 and 2 are successful, while Test 3 is not. I've tried several methods to make it work, even referencing the page redirect check from the TopBar test, but this test still fails. The successful tests do count as 100% coverage for the SidebarButton component, however, so I decided to still add this test case. Test 3 is still included in the test file commented out if anyone wants to take a look. 

## Testing
According to jest, this test has 100% coverage for the SidebarButton component. Obviously there's more to test but that'll have to wait for the future.
## Possible Errors
Test 3 doesn't work properly so something is wrong there. Otherwise I think these tests are enough to test the SidebarButton component. This could be proven wrong in the future, whether through an oversight in testing or an edit of the component.
## Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/337f2fef-4136-40fd-aac3-65e486eee30d)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/f3012381-fd24-433d-9fba-54bca83ae65a)
Current test coverage as of this pull request.
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/ef7829fe-cdf9-4805-8ba3-18ad286aa4cd)
Individual test cases passing.