### PR TITLE
Added test cases for accountCreate/page.js & logo change in login/register

### DIFF
--- a/small-talk/app/accountCreate/page.js
+++ b/small-talk/app/accountCreate/page.js
@@ -30,7 +30,6 @@ export default function RegisterPage() {
       else{
         alert("Registration was unsuccessful");
       }
-      
     };
   
     const checkUP = async (event) => {
@@ -44,26 +43,6 @@ export default function RegisterPage() {
           return;
         }
         
-        if(!(await validateInput(username))){
-          alert("Username: Too many characters or Use of prohibited characters");
-          return;
-        }
-
-        if(await vulgar(username)){
-          alert("*** Username: Vulgar Language Detected ***");
-          return;
-        }
-
-        if(!(await validateInput(password))){
-          alert("Password: Too many characters or Use of prohibited characters");
-          return;
-        }
-
-        if(await vulgar(password)){
-          alert("*** Password: Vulgar Language Detected ***");
-          return;
-        }
-        
         if(!(await validateInput(firstName))){
           alert("First Name: Too many characters or Use of prohibited characters");
           return;
@@ -73,7 +52,26 @@ export default function RegisterPage() {
           alert("Last Name: Too many characters or Use of prohibited characters");
           return;
         }
-        
+
+        if(!(await validateInput(username))){
+          alert("Username: Too many characters or Use of prohibited characters");
+          return;
+        }
+
+        if(!(await validateInput(password))){
+          alert("Password: Too many characters or Use of prohibited characters");
+          return;
+        }
+
+        if(await vulgar(username)){
+          alert("*** Username: Vulgar Language Detected ***");
+          return;
+        }
+
+        if(await vulgar(password)){
+          alert("*** Password: Vulgar Language Detected ***");
+          return;
+        }
         
         if(username.toLowerCase().includes(firstName.toLowerCase()) || username.toLowerCase().includes(lastName.toLowerCase())){
           alert("Username cannot contain first or last name.");
@@ -111,15 +109,9 @@ export default function RegisterPage() {
   
     return (
       <div className="h-screen w-screen flex flex-col items-center justify-center text-black">
-        {(textInput == null) ? <div></div>: <div className="text-white">hello {textInput.firstname}</div>}
           <img src="/placeholder-logo.png" alt="Description of the image"></img>
         <div className="rounded-md bg-sky-500/50 p-10 m-4">
-        <form action={async (formData) => {
-          const data = await handleSubmit(formData)
-          if (data != null) {
-            setTextInput(data)
-          }
-        }}>
+        <form action>
             <div>
                 <label
                     for="fName"

--- a/small-talk/app/accountCreate/page.js
+++ b/small-talk/app/accountCreate/page.js
@@ -109,7 +109,7 @@ export default function RegisterPage() {
   
     return (
       <div className="h-screen w-screen flex flex-col items-center justify-center text-black">
-          <img src="/placeholder-logo.png" alt="Description of the image"></img>
+          <img src="/img/logo.png" alt="Description of the image" width='300'></img>
         <div className="rounded-md bg-sky-500/50 p-10 m-4">
         <form action>
             <div>

--- a/small-talk/app/accountCreate/page.test.js
+++ b/small-talk/app/accountCreate/page.test.js
@@ -25,7 +25,7 @@ describe('RegisterPage Component', () => {
 
   it('allows input fields to be filled', () => {
     render(<RegisterPage />);
-    const firstNameInput = screen.getByPlaceholderText('John');
+    const firstNameInput = screen.getByPlaceholderText('John'); // hold the credentials for each field in accountCreate
     const lastNameInput = screen.getByPlaceholderText('Doe');
     const dobInput = screen.getByPlaceholderText('Date of Birth');
     const usernameInput = screen.getByPlaceholderText('Username');
@@ -37,27 +37,295 @@ describe('RegisterPage Component', () => {
     fireEvent.change(usernameInput, { target: { value: 'testuser' } });
     fireEvent.change(passwordInput, { target: { value: 'Test@1234' } });
 
-    expect(firstNameInput.value).toBe('Test');
+    expect(firstNameInput.value).toBe('Test'); // assert that the values are the same inputted
     expect(lastNameInput.value).toBe('User');
     expect(dobInput.value).toBe('1990-01-01');
     expect(usernameInput.value).toBe('testuser');
     expect(passwordInput.value).toBe('Test@1234');
   });
 
+  it('shows an alert for having any field empty', async () => {
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: '' } }); // fields are empty
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: '' } }); 
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: '' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await expect(window.alert).toHaveBeenCalledWith("All fields are necessary!"); // assert that the alert displays "All fields are necessary"
+  });
+
+  // Following test cases are regards to invalid credentials due to prohibited characters
+  it('shows an alert for invalid first name due to prohibited characters', async () => {
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test>' } });  // first name contains prohibited character
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsername' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'invalid>PWord1!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => expect(validateInput).toHaveBeenCalledWith('Test>')); // assert that validateInput was called with the invalid first name
+    await expect(window.alert).toHaveBeenCalledWith("First Name: Too many characters or Use of prohibited characters");
+  });
+  
+  it('shows an alert for invalid last name due to prohibited characters', async () => {
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for first name
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User>' } }); // last name contains prohibited character
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsername' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'invalid>PWord1!' } }); 
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => expect(validateInput).toHaveBeenCalledWith('User>'));// assert that validateInput was called with the invalid last name
+    await expect(window.alert).toHaveBeenCalledWith("Last Name: Too many characters or Use of prohibited characters");
+  });
 
 
-  /* Below are where more tests should be added */
-//   it('shows an alert for invalid username due to prohibited characters', async () => {
-//     validateInput.mockResolvedValueOnce(false); // Simulate validation failure for username
-//     vulgar.mockResolvedValueOnce(false); // Assume no vulgar language for simplicity
+  it('shows an alert for invalid username due to prohibited characters', async () => {
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for first name
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for last name
   
-//     render(<RegisterPage />);
-//     fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'invalidUsername!' } });
-//     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'ValidPassword1!' } });
-//     fireEvent.click(screen.getByText('Submit'));
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'invalid/Username!<' } }); // username contains prohibited character
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'ValidPWord1!' } });
+    fireEvent.click(screen.getByText('Submit'));
   
-//     await waitFor(() => expect(validateInput).toHaveBeenCalledWith('invalidUsername!'));
-//     expect(window.alert).toHaveBeenCalledWith("Username: Too many characters or Use of prohibited characters");
-//   });
-//   // More tests will be added here
+    await waitFor(() => expect(validateInput).toHaveBeenCalledWith('invalid/Username!<'));// assert that validateInput was called with the invalid username
+    await expect(window.alert).toHaveBeenCalledWith("Username: Too many characters or Use of prohibited characters");
+  });
+
+
+  it('shows an alert for invalid password due to prohibited characters', async () => {
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for first name
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for last name
+    validateInput.mockResolvedValueOnce(true); // Simulate validation success for username 
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsername' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'invalid>PWord1!' } });  // password contains prohibited character
+    fireEvent.click(screen.getByText('Submit'));
+  
+
+    await waitFor(() => {
+      expect(validateInput).toHaveBeenCalledWith('invalid>PWord1!');// assert that validateInput was called with the invalid password
+      expect(window.alert).toHaveBeenCalledWith("Password: Too many characters or Use of prohibited characters");
+    });
+  });
+
+
+  it('shows an alert for vulgar language in username', async () => {
+    validateInput.mockResolvedValueOnce(true); // simulate validation success for 4 main fields
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    vulgar.mockResolvedValueOnce(true); 
+
+      render(<RegisterPage />);
+      fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+      fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User' } });
+      fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+      fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'assWonderful' } }); // username contains vulgar language
+      fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+      fireEvent.click(screen.getByText('Submit'));
+
+      await waitFor(() => {
+          expect(vulgar).toHaveBeenCalledWith('assWonderful'); // Check if vulgar function is called with the correct argument
+          expect(window.alert).toHaveBeenCalledWith("*** Username: Vulgar Language Detected ***");
+      });
+  });
+
+  it('shows an alert for vulgar language in password', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    vulgar.mockResolvedValueOnce(false); // simulate validation for vulgar check on username
+    vulgar.mockResolvedValueOnce(true); // .. for password
+
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'User' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'Welcome' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'assWonderful1!' } }); // password contains vulgar language
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+        expect(vulgar).toHaveBeenCalledWith('assWonderful1!'); // Check if vulgar function is called with the correct argument
+        expect(window.alert).toHaveBeenCalledWith("*** Password: Vulgar Language Detected ***");
+    });
+  });
+
+
+  it('shows an alert if the username is included in the password', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsername' } }); // username is in the password
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'validUsername!' } });
+    fireEvent.click(screen.getByText('Submit'));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Username cannot contain password or vice versa.");
+    });
+  });
+
+  it('shows an alert if the first name is included in the username', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } }); // first name is included in the username
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsernameTest' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'validPWord!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Username cannot contain first or last name.");
+    });
+  });
+
+  it('shows an alert if the last name is included in the password', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } }); // last name is included in the password
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'validUsername' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'CasevalidPWord!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Password cannot contain first or last name.");
+    });
+  });
+
+  it('shows an alert if the username is already taken', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    userExists.mockResolvedValueOnce(false); // ensure that the userExists function returns false
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'jd1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Username is already taken!");
+    });
+  });
+
+  it('shows an alert if the password does not follow the allowed pattern', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'jd1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'lime1234' } }); // password does not contain capital nor special character
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Password must contain at least: \n- one number \n- one uppercase letter \n- one lowercase letter \n- eight(8) characters");
+    });
+  });
+
+  it('shows an alert if registration was unsuccessful', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    handleRegister.mockResolvedValueOnce(!null); // handleRegister does return a user
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Registration was SUCCESSFUL"); // handleRegister didn't return null
+    });
+  });
+
+  it('shows an alert if registration was unsuccessful', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    handleRegister.mockResolvedValueOnce(null); // registration fails, credentials not saved in the DB
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Registration was unsuccessful"); // handleRegister returned null
+    });
+  });
+
+  it('redirects to login page when goLogin is called', () => {
+    render(<RegisterPage />);
+    
+    // Mock the window.location.href setter
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { href: '' };
+
+    // Trigger the goLogin function
+    fireEvent.click(screen.getByText('Cancel'));
+
+    // Assert that window.location.href is set to '/login'
+    expect(window.location.href).toBe('/login');
+
+    // Restore the original window.location
+    window.location = originalLocation;
+  });
 });

--- a/small-talk/app/login/page.js
+++ b/small-talk/app/login/page.js
@@ -47,8 +47,8 @@ export default function LoginPage() {
 
   return (
     <div className="h-screen w-screen flex flex-col items-center justify-center text-black">
-        <img src="/placeholder-logo.png" alt="Description of the image"></img>
-      <div className="rounded-md bg-sky-500/50 p-10 m-4">
+        <img src="/img/logo.png" alt="Description of the image" width='300'></img>
+      <div className="rounded-md bg-sky-500/50 p-5 m-4">
       {/* <form action={async (formData) => {
         const data = await handleSubmit(formData)
         if (data != null) {


### PR DESCRIPTION
## Added test cases for accountCreate/page.js & logo change in login/register 

## Issue Number
#58 and #76 

## Description

- Added test cases for the file accountCreate/page.js, which is one of the big files that needed test coverage:
    √ renders correctly                                                                                                                                                                                   
    √ allows input fields to be filled                                                                                                                                                                   
    √ shows an alert for having any field empty                                                                                                                                                           
    √ shows an alert for invalid first name due to prohibited characters                                                                                                                               
    √ shows an alert for invalid last name due to prohibited characters                                                                                                                                 
    √ shows an alert for invalid username due to prohibited characters                                                                                                                                    
    √ shows an alert for invalid password due to prohibited characters                                                                                                                                
    √ shows an alert for vulgar language in username                                                                                                                                                      
    √ shows an alert for vulgar language in password                                                                                                                                                  
    √ shows an alert if the username is included in the password                                                                                                                                         
    √ shows an alert if the first name is included in the username                                                                                                                                    
    √ shows an alert if the last name is included in the password                                                                                                                                      
    √ shows an alert if the username is already taken                                                                                                                                                    
    √ shows an alert if the password does not follow the allowed pattern                                                                                                                        
    √ shows an alert if registration was unsuccessful                                                                                                                                                    
    √ shows an alert if registration was unsuccessful                                                                                                                                                    
    √ redirects to login page when goLogin is called
- Changed the logo in the login page to the more appropriate asset.

## Testing
This pull request adds 100% test coverage to the accountCreate/page.js file

## Possible Errors
No possible errors, but I may have missed some edge cases, please let me know if you spot one.

## Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/124417373/e47d02b8-5187-40fc-b099-602647cb1c02)

our current test coverage:
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/124417373/7f80c2b1-d031-4208-a2b1-209f537addec)


logo before:
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/124417373/568cb7fb-56e7-445b-9e2f-93d09d0e9381)


logo after:
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/124417373/c9430e45-81f6-44ee-9912-a92e03797795)


