### PR TITLE
Implemented Censoring In Chat

### DIFF
--- a/small-talk/app/chat/page.js
+++ b/small-talk/app/chat/page.js
@@ -5,6 +5,7 @@ import socket from "../../util/socket";
 import React, { useEffect, useState } from 'react';
 import FriendsList from '../components/friends/FriendsList';
 import handleMessageSave from "@/db/messageSave"
+import censor from '@/components/censorMess';
 
 export default function Chat(){
 	const [user, setUser] = useState([]);
@@ -123,11 +124,13 @@ export default function Chat(){
 
 export const sendMessage = (inputMessage, selectedUser, setPrivateMessages, setInputMessage, room) => {
     if (typeof inputMessage === 'string' && inputMessage.trim() !== "" && selectedUser && typeof setPrivateMessages === 'function' && typeof setInputMessage === 'function') {
-        console.log("sent message from:" + selectedUser.username + " with message: " + inputMessage);
-        socket.emit("private message", { content: inputMessage, to: selectedUser.userID});
-        setPrivateMessages(prevMessages => [...prevMessages, { content: inputMessage, from: socket.id }]);
+		const censorMessage = censor(inputMessage);
+		
+		console.log("sent message from:" + selectedUser.username + " with message: " + censorMessage);
+        socket.emit("private message", { content: censorMessage, to: selectedUser.userID});
+        setPrivateMessages(prevMessages => [...prevMessages, { content: censorMessage, from: socket.id }]);
         setInputMessage("");
-        handleMessageSave(inputMessage);
+        handleMessageSave(censorMessage);
     } else {
         console.log("No user selected or empty message");
     }

--- a/small-talk/components/censorMess.js
+++ b/small-talk/components/censorMess.js
@@ -1,10 +1,12 @@
 import swearWords from './swearWords.js';
 
 export default function censor(input) {
-    const inputinput = input.toLowerCase(); // make sure check for all cases
-    let censored = inputinput;
+    let censored = input;
     for (let swearWord of swearWords) { // check for all swear words
         const regex = new RegExp(`\\b${swearWord}\\b`, 'gi'); // used AI to match words and replace
+        // checks for case insensitivity
+        // returns unaltered message otherwise
+     
         censored = censored.replace(regex, '*'.repeat(swearWord.length)); // replaces vulgar language with ****
     }
     return censored;

--- a/small-talk/components/censorMess.js
+++ b/small-talk/components/censorMess.js
@@ -1,0 +1,11 @@
+import swearWords from './swearWords.js';
+
+export default function censor(input) {
+    const inputinput = input.toLowerCase(); // make sure check for all cases
+    let censored = inputinput;
+    for (let swearWord of swearWords) { // check for all swear words
+        const regex = new RegExp(`\\b${swearWord}\\b`, 'gi'); // used AI to match words and replace
+        censored = censored.replace(regex, '*'.repeat(swearWord.length)); // replaces vulgar language with ****
+    }
+    return censored;
+}


### PR DESCRIPTION

Issue Number
#110 

Description
I have implemented vulgar language detection for the chat. Instead of prompting an error code and rejecting the chat, it will censor with **** for the length of the word. I made a new file for the function that it uses to do this. 

Testing
I will work on testing for this later. I have performed testing of my own to ensure it is operational . 

Possible Errors
If the word is spaced out e.g ( A P P L E S ) it will not detect the word apples. 

Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156858913/a380bdb4-2f7f-44ff-816a-2ece8f99277f)
This is a demonstration of it in use.