### PR TITLE
Added very basic content to Events page

### DIFF
--- a/small-talk/__tests__/pages/events/index.test.js
+++ b/small-talk/__tests__/pages/events/index.test.js
@@ -5,7 +5,7 @@ import Events from '../../../pages/events/index.js';
 describe("Events Page", () => {
     it("Makes sure Events page content renders properly", () => {
         render(<Events />);
-        const titleElement = screen.getByText("Events Page");
+        const titleElement = screen.getByText("Today's Events");
         expect(titleElement).toBeInTheDocument();
     })
 })

--- a/small-talk/pages/events/index.js
+++ b/small-talk/pages/events/index.js
@@ -14,7 +14,55 @@ export const Events = ({data}) =>{
     return(
         <div className='bg-slate-800 text-white'>
             <Layout width={windowWidth} renderHeader={true} renderFooter={true}>
-                <h1>Events Page</h1>
+                <h1 className = 'font-bold'>Today's Events</h1>
+                <ul className = 'divide-y divide-solid'>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-2</li>
+                            <li>Toy Drive</li>
+                            <li>Toys donated to the hospital will be distributed to patients starting at 12:00pm.</li>
+                        </ul>
+                    </li>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-2</li>
+                            <li>Meetup with Timmy</li>
+                            <li>Timmy and I will hangout together and play Roblox!!</li>
+                        </ul>
+                    </li>
+                </ul>
+
+                <h1 className = 'font-bold pt-10'>Upcoming Events</h1>
+                <ul className = 'divide-y divide-solid'>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-5</li>
+                            <li>Therapy Dog Visit</li>
+                            <li>Therapy dogs from the local dog trainer will visit the hospital at 10:00am.</li>
+                        </ul>
+                    </li>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-9</li>
+                            <li>Doctor's Appointment</li>
+                            <li>I have my regular appointment with Doctor Lee today, don't forget!!</li>
+                        </ul>
+                    </li>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-11</li>
+                            <li>Amy's Birthday!</li>
+                            <li>Today is Amy's birthday!! We're going to have so much fun!!!</li>
+                        </ul>
+                    </li>
+                    <li className = 'list-disc'>
+                        <ul>
+                            <li>2024-5-17</li>
+                            <li>CUPCAKE DAY!!</li>
+                            <li>CUPCAKES!!!!!!!!!!!</li>
+                        </ul>
+                    </li>
+                </ul>
             </Layout>  
         </div>
     )

--- a/small-talk/pages/events/index.js
+++ b/small-talk/pages/events/index.js
@@ -14,7 +14,7 @@ export const Events = ({data}) =>{
     return(
         <div className='bg-slate-800 text-white'>
             <Layout width={windowWidth} renderHeader={true} renderFooter={true}>
-                <h1 className = 'font-bold'>Today's Events</h1>
+                <h1 className = 'font-bold'>Today&apos;s Events</h1>
                 <ul className = 'divide-y divide-solid'>
                     <li className = 'list-disc'>
                         <ul>
@@ -44,15 +44,15 @@ export const Events = ({data}) =>{
                     <li className = 'list-disc'>
                         <ul>
                             <li>2024-5-9</li>
-                            <li>Doctor's Appointment</li>
-                            <li>I have my regular appointment with Doctor Lee today, don't forget!!</li>
+                            <li>Doctor&apos;s Appointment</li>
+                            <li>I have my regular appointment with Doctor Lee today, don&apos;t forget!!</li>
                         </ul>
                     </li>
                     <li className = 'list-disc'>
                         <ul>
                             <li>2024-5-11</li>
-                            <li>Amy's Birthday!</li>
-                            <li>Today is Amy's birthday!! We're going to have so much fun!!!</li>
+                            <li>Amy&apos;s Birthday!</li>
+                            <li>Today is Amy&apos;s birthday!! We&apos;re going to have so much fun!!!</li>
                         </ul>
                     </li>
                     <li className = 'list-disc'>


### PR DESCRIPTION
## Added very basic content to Events page
## Issue Number
Works on Issue #149 
## Description
Added very basic static content to the Events page. Currently it just has two separate categories for Today's Events and Upcoming Events each with a list of events. Events have a date, title, and description. In the future, I plan on creating components to make adding and listing events easier. I just wanted to get some basic content onto the page for now.
## Testing
I edited the test for the Events page so that it will pass. Right now it just checks if "Today's Events" is present. When I finish the page completely the test will have to be changed to cover everything.
## Possible Errors
No errors since it's static content. I'm open to suggestions for event content or overall formatting, however.
## Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/cbaa17ff-9317-41fb-975a-01684ed876ed)
Current content for Events page.