### PR TITLE
Test Coverage for footer, privacy policy, account create w/ @salazw1

### DIFF
--- a/small-talk/__tests__/pages/privacyPolicy/index.test.js
+++ b/small-talk/__tests__/pages/privacyPolicy/index.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import PP from '../../../pages/privacyPolicy/index.js';
+describe("Privacy Page", () => {
+    it("Makes sure Privacy Policy page content renders properly", () => {
+        render(<PP />);
+        //await waitFor(()) => {
+        const titleElement = screen.getByText("Privacy Policy", { selector: 'h2' });
+        expect(titleElement).toBeInTheDocument();
+        //});
+    
+    })
+})

--- a/small-talk/app/accountCreate/page.test.js
+++ b/small-talk/app/accountCreate/page.test.js
@@ -269,7 +269,7 @@ describe('RegisterPage Component', () => {
     });
   });
 
-  it('shows an alert if registration was unsuccessful', async () => {
+  it('shows an alert if registration was successful', async () => {
     validateInput.mockResolvedValueOnce(true);
     validateInput.mockResolvedValueOnce(true);
     validateInput.mockResolvedValueOnce(true);
@@ -283,10 +283,13 @@ describe('RegisterPage Component', () => {
     fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
     fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    const privacyCheckbox = screen.getByRole('checkbox');
+    fireEvent.click(privacyCheckbox); // Uncheck the privacy policy checkbox
     fireEvent.click(screen.getByText('Submit'));
   
     await waitFor(() => {
-      expect(window.alert).toHaveBeenCalledWith("Registration was SUCCESSFUL"); // handleRegister didn't return null
+      //expect(window.alert).toHaveBeenCalledWith("Please agree to the Privacy Policy / Terms & Conditions."); 
+      expect(window.alert).toHaveBeenCalledWith("Registration was SUCCESSFUL");// handleRegister didn't return null
     });
   });
 
@@ -304,9 +307,13 @@ describe('RegisterPage Component', () => {
     fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
     fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    //fireEvent.click(screen.getAllByLabelText('privacyCheckbox'), { target: { value: true } });
+    const privacyCheckbox = screen.getByRole('checkbox');
+    fireEvent.click(privacyCheckbox); // Uncheck the privacy policy checkbox
     fireEvent.click(screen.getByText('Submit'));
   
     await waitFor(() => {
+      //expect(window.alert).toHaveBeenCalledWith("Please agree to the Privacy Policy / Terms & Conditions.");
       expect(window.alert).toHaveBeenCalledWith("Registration was unsuccessful"); // handleRegister returned null
     });
   });
@@ -333,5 +340,50 @@ describe('RegisterPage Component', () => {
 
     // Restore the original window.location
     window.location = originalLocation;
+  });
+
+  it('shows an alert if privacy checkbox is not checked', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    handleRegister.mockResolvedValueOnce(!null); // handleRegister does return a user
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '1990-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("Please agree to the Privacy Policy / Terms & Conditions."); 
+    });
+  });
+
+  it('shows an alert if registration was successful', async () => {
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+    validateInput.mockResolvedValueOnce(true);
+
+    handleRegister.mockResolvedValueOnce(!null); // handleRegister does return a user
+  
+    render(<RegisterPage />);
+    fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Case' } });
+    fireEvent.change(screen.getByPlaceholderText('Date of Birth'), { target: { value: '2022-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'od1924' } });
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'Lime1234!' } });
+    const privacyCheckbox = screen.getByRole('checkbox');
+    fireEvent.click(privacyCheckbox); // Uncheck the privacy policy checkbox
+    fireEvent.click(screen.getByText('Submit'));
+  
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith("By using this web app, you confirm that you are 13 years of age or older, or have obtained parental consent. If you are under 13, please do not use this app without parental permission. We are committed to protecting the privacy of children online and comply with the Children's Online Privacy Protection Act (COPPA). For more information, please review our Privacy Policy.");
+    });
   });
 });

--- a/small-talk/components/footer.js
+++ b/small-talk/components/footer.js
@@ -10,10 +10,6 @@ export const Footer = () => {
     const goPP = () => {
         window.location.href = "/privacyPolicy"; // Redirect to the login
     }
-    const [showPopup, setShowPopup] = useState(false);
-    const togglePopup = () => {
-        setShowPopup(!showPopup);
-    };
     
     return (
         <div className="flex flex-col items-center justify-between w-screen h-[24px] text-slate-50 bg-slate-700 fixed bottom-0 px-4">
@@ -29,17 +25,6 @@ export const Footer = () => {
                     {"Privacy Policy"}
                 </button>
             </div>
-
-            {/* Popup */}
-            {showPopup && (
-                <div className="popup">
-                    <div className="popup-content">
-                        <span className="close" onClick={togglePopup}>&times;</span>
-                        {/* Your popup content */}
-                        <p>This is the content of the popup window.</p>
-                    </div>
-                </div>
-            )}
         </div>
     );
 }

--- a/small-talk/components/footer.test.js
+++ b/small-talk/components/footer.test.js
@@ -1,6 +1,6 @@
 import Footer from './footer.js';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 //ai-gen start (ChatGPT-4, 1)
 describe('Footer component', () => {
     it('should render without crashing', () => {
@@ -13,5 +13,23 @@ describe('Footer component', () => {
         const currentYear = new Date().getFullYear();
         expect(screen.getByText(/SmallTalk © \d{4}/)).toBeInTheDocument();
     });
+
+    it('redirects to privacy policy page whenn clicked in footer', () => {
+        render(<Footer />);
+        
+        // Mock the window.location.href setter
+        const originalLocation = window.location;
+        delete window.location;
+        window.location = { href: '' };
+    
+        // Trigger the goLogin function
+        fireEvent.click(screen.getByText('Privacy Policy'));
+    
+        // Assert that window.location.href is set to '/login'
+        expect(window.location.href).toBe('/privacyPolicy');
+    
+        // Restore the original window.location
+        window.location = originalLocation;
+      });
 });
 //ai-gen end


### PR DESCRIPTION
Test Coverage for footer, privacy policy, account create w/ @salazw1

Issue Number
#207 #206 #205 #192

Description
Warren and I (with the help of Johnson and Jun) were able to increase test coverage by writing test cases for account create, footer, and privacy policy. We had to add onto the previously existing account create tests because we added new criterea to the creating account process. The affected PR we added coverage to is #193 

Testing
We have completed the testing for the affected files with my partnership with warren @salazw1. We worked together on the PR merge #193 and this was the test cases to follow. 

Possible Errors
no errors found

Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156858913/883d4e96-9b92-42e5-b602-61bcbd5d8428)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156858913/bc0990cb-39ab-48bb-a9f6-66ca17ee576f)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156858913/ed45b474-0c9e-4021-9d5e-e319a1c2b5a1)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/156858913/aa2698d1-40ef-45ec-8a11-d34a44073734)

