### PR TITLE
Updated Events page formatting and added Past Events section

### DIFF
--- a/small-talk/app/components/EventsList.js
+++ b/small-talk/app/components/EventsList.js
@@ -1,5 +1,4 @@
-import { compare } from 'bcryptjs';
-import React from 'react';
+import React, { useState } from 'react';
 
 function EventsList({events})
 {
@@ -48,11 +47,13 @@ function EventsList({events})
     const listEvent = (event) =>
     {
         return(
-            <div>
-                <li>{event.date.year}-{event.date.month}-{event.date.day}</li>
-                <li className = 'font-semibold'>{event.title}</li>
+            <ul className = 'bg-amber-500 rounded-lg p-3 divide-y divide-solid divide-gray-800'>
+                <li className = 'grid grid-cols-2'>
+                    <span className = 'font-semibold text-left'>{event.title}</span> 
+                    <span className = 'text-right'>{event.date.year}-{event.date.month}-{event.date.day}</span>
+                </li>
                 <li>{event.description}</li>
-            </div>
+            </ul>
         );
     };
 
@@ -75,20 +76,47 @@ function EventsList({events})
             return(listEvent(event));
         }
     }
+    
+    // Check if given event is in past, if so list it
+    const listPastEvents = (event) =>
+    {
+        // Compare today's date and event's date -- see if event's date is in past
+        if(compareDates(event) == -1)
+        {
+            return(listEvent(event));
+        }
+    }
+
+    // Dropdown for past events
+    const [subTab, setSubTab] = useState('');
+
+    // Handle past events tab click
+    const handleSubTabChange = (tab) => {
+        setSubTab(subTab === tab ? '' : tab);
+    };
 
     return(
         <div className = 'space-y-10'> {/* Adds space between event categories */}
-            <div className = 'bg-white rounded-lg text-gray-800 text-center my-10'>
-                <h2 className = 'font-bold'>Today&apos;s Events</h2>
-                <ul className = 'divide-y divide-solid'>
+            <div className = 'bg-white rounded-lg text-gray-800 my-10'>
+                <h2 className = 'font-bold text-center pt-4'>Today&apos;s Events</h2>
+                <ul className = 'p-4 flex-col-reverse space-y-3'>
                     {events.map(listTodaysEvents) /* Lists all events occurring today */} 
                 </ul>
             </div>
     
-            <div className = 'bg-white rounded-lg text-gray-800 text-center'>
-                <h2 className = 'font-bold'>Upcoming Events</h2>
-                <ul className = 'divide-y divide-solid'>
-                    {events.map(listUpcomingEvents) /* Lists all events occuring in future */}
+            <div className = 'bg-white rounded-lg text-gray-800'>
+                <h2 className = 'font-bold text-center pt-4'>Upcoming Events</h2>
+                <ul className = 'p-4 flex-col-reverse space-y-3'>
+                    {events.map(listUpcomingEvents) /* Lists all events occurring in future */}
+                </ul>
+            </div>
+
+            <div className = 'bg-white rounded-lg text-gray-800 flex flex-col'>
+                <button onClick = {() => handleSubTabChange('past')}>
+                    <h2 className = {`font-bold text-center ${subTab == 'past' ? 'pt-4' : ''}`}>Past Events {subTab == 'past' ? '▲' : '▼'}</h2>
+                </button>
+                <ul className = {`flex-col-reverse space-y-3 ${subTab == 'past' ? 'p-4' : ''}`}>
+                    {subTab == 'past' && events.map(listPastEvents) /* Lists all events occurred in past when clicked */}
                 </ul>
             </div>
         </div>

--- a/small-talk/app/components/EventsList.js
+++ b/small-talk/app/components/EventsList.js
@@ -47,7 +47,7 @@ function EventsList({events})
     const listEvent = (event) =>
     {
         return(
-            <ul className = 'bg-amber-500 rounded-lg p-3 divide-y divide-solid divide-gray-800'>
+            <ul className = 'bg-gradient-to-r from-amber-400 to-orange-400 rounded-lg p-3 divide-y divide-solid divide-gray-800 '>
                 <li className = 'grid grid-cols-2'>
                     <span className = 'font-semibold text-left'>{event.title}</span> 
                     <span className = 'text-right'>{event.date.year}-{event.date.month}-{event.date.day}</span>
@@ -98,14 +98,14 @@ function EventsList({events})
     return(
         <div className = 'space-y-10'> {/* Adds space between event categories */}
             <div className = 'bg-white rounded-lg text-gray-800 my-10'>
-                <h2 className = 'font-bold text-center pt-4'>Today&apos;s Events</h2>
+                <h2 className = 'font-bold text-center pt-4 text-lg'>Today&apos;s Events</h2>
                 <ul className = 'p-4 flex-col-reverse space-y-3'>
                     {events.map(listTodaysEvents) /* Lists all events occurring today */} 
                 </ul>
             </div>
     
             <div className = 'bg-white rounded-lg text-gray-800'>
-                <h2 className = 'font-bold text-center pt-4'>Upcoming Events</h2>
+                <h2 className = 'font-bold text-center pt-4 text-lg'>Upcoming Events</h2>
                 <ul className = 'p-4 flex-col-reverse space-y-3'>
                     {events.map(listUpcomingEvents) /* Lists all events occurring in future */}
                 </ul>
@@ -113,12 +113,13 @@ function EventsList({events})
 
             <div className = 'bg-white rounded-lg text-gray-800 flex flex-col'>
                 <button onClick = {() => handleSubTabChange('past')}>
-                    <h2 className = {`font-bold text-center ${subTab == 'past' ? 'pt-4' : ''}`}>Past Events {subTab == 'past' ? '▲' : '▼'}</h2>
+                    <h2 className = {`font-bold text-center text-lg ${subTab == 'past' ? 'pt-4' : ''}`}>Past Events {subTab == 'past' ? '▲' : '▼'}</h2>
                 </button>
                 <ul className = {`flex-col-reverse space-y-3 ${subTab == 'past' ? 'p-4' : ''}`}>
                     {subTab == 'past' && events.map(listPastEvents) /* Lists all events occurred in past when clicked */}
                 </ul>
             </div>
+            <div className = 'divide-y divide-solid'></div>
         </div>
 
 

--- a/small-talk/app/data/eventsData.json
+++ b/small-talk/app/data/eventsData.json
@@ -14,7 +14,7 @@
         {
             "year":  "2024",
             "month": "4",
-            "day":   "22"
+            "day":   "23"
         },
         "title": "Meetup with Timmy",
         "description": "Timmy and I will hangout together and play Roblox!!"

--- a/small-talk/pages/events/index.js
+++ b/small-talk/pages/events/index.js
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from "react";
 import Layout from "@/components/layout";
 import EventsList from "@/app/components/EventsList";
 import eventsData from "@/app/data/eventsData";
+import Title from '@/components/title'
 
 export const Events = ({data}) =>{
     const [windowWidth, setWindowWidth] = useState(null);
@@ -16,6 +17,7 @@ export const Events = ({data}) =>{
     return(
         <div className='bg-slate-800 text-white'>
             <Layout width={windowWidth} renderHeader={true} renderFooter={true}>
+                <Title page = "Events" />
                 <EventsList events = {eventsData} /> {/* Render EventsList using data from JSON */}
             </Layout>  
         </div>


### PR DESCRIPTION
## Updated Events page formatting and added Past Events section
## Issue Number
Closes #149 
## Description
Updated Events page formatting to include some color and adjust the positions of event details. Added Past Events category in `EventsList` that lists any events with dates before today's date. Also updated an event's date in the JSON to be today's date so that there are events in each category (for today). 
## Testing
After this PR the Events page is pretty much finished besides any minor edits, so the tests for this page can finally be made (if anyone still wants to make them).
## Possible Errors
Shouldn't be any errors with the Past Events feature from what I've seen.
## Images
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/ee97ce9d-50b2-419a-94eb-5dad6181776d)
Updated Events page with formatting changes and new Past Events category that is unexpanded.
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP4-SMTK/assets/92517582/c9eea6fb-34cd-4a8a-a906-657b7c62d80c)
Events page with Past Events category expanded.